### PR TITLE
Send snapshots on each submit

### DIFF
--- a/tmc-plugin/src/fi/helsinki/cs/tmc/actions/SubmitExerciseAction.java
+++ b/tmc-plugin/src/fi/helsinki/cs/tmc/actions/SubmitExerciseAction.java
@@ -3,6 +3,8 @@ package fi.helsinki.cs.tmc.actions;
 import fi.helsinki.cs.tmc.exerciseSubmitter.ExerciseSubmitter;
 import fi.helsinki.cs.tmc.model.CourseDb;
 import fi.helsinki.cs.tmc.model.ProjectMediator;
+import fi.helsinki.cs.tmc.spyware.SpywareFacade;
+
 import org.netbeans.api.project.Project;
 import org.openide.nodes.Node;
 import org.openide.util.NbBundle.Messages;
@@ -35,6 +37,7 @@ public final class SubmitExerciseAction extends AbstractExerciseSensitiveAction 
     @Override
     protected void performAction(Node[] nodes) {
         new ExerciseSubmitter().performAction(projectsFromNodes(nodes).toArray(new Project[0]));
+        SpywareFacade.sendNow();
     }
 
     @Override
@@ -47,5 +50,8 @@ public final class SubmitExerciseAction extends AbstractExerciseSensitiveAction 
         // The setting in layer.xml doesn't work with NodeAction
         return "fi/helsinki/cs/tmc/actions/submit.png";
     }
-    
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 7fd9e4e... Send snapshots on each submit to make sure to have all relevant


### PR DESCRIPTION
to make sure to have all relevant snapshots sent when user has submitted the exercise.

Background, plenty of students at UH are using guest accounts for unix systems and sometimes for these users we are missing last few events before submitting last exercise and then logging out/stopping working on tmc-exercises.

In theory better solution would be also to send the snapshots when closing netbeans, but I don't really like the idea of delaying netbeans when closing up...
